### PR TITLE
fix 6 - auto tile generator

### DIFF
--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/lists/auto-tile/dialog/items/@nodeinfo.xml
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/lists/auto-tile/dialog/items/@nodeinfo.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <node nodeType="cq:Widget">
-  <properties />
+  <properties>
+    <property name="xtype" type="1" multiple="false">
+      <value><![CDATA[tabpanel]]></value>
+    </property>
+  </properties>
   <mixins />
 </node>
 


### PR DESCRIPTION
restoring the xtype property to the malformed node which should confirm that it is fixed
