### PR TITLE
CSS Asset Fix

### DIFF
--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/page/htmlbase/clientlibs/css/style.css
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/page/htmlbase/clientlibs/css/style.css
@@ -3974,8 +3974,8 @@ input[disabled]:focus,
  */
 @font-face {
     font-family: 'cruicons';
-    src: url("assets/fonts/cruicons.eot?13550619");
-    src: url("assets/fonts/cruicons.eot?13550619#iefix") format("embedded-opentype"), url("assets/fonts/cruicons.woff?13550619") format("woff"), url("assets/fonts/cruicons.ttf?13550619") format("truetype"), url("assets/fonts/cruicons.svg?13550619#cruicons") format("svg");
+    src: url("/fonts/cruicons.eot?13550619");
+    src: url("/fonts/cruicons.eot?13550619#iefix") format("embedded-opentype"), url("/fonts/cruicons.woff?13550619") format("woff"), url("/fonts/cruicons.ttf?13550619") format("truetype"), url("assets/fonts/cruicons.svg?13550619#cruicons") format("svg");
     font-weight: normal;
     font-style: normal; }
 /* Chrome hack: SVG is rendered more smooth in Windozze. 100% magic, uncomment if you need it. */
@@ -3984,7 +3984,7 @@ input[disabled]:focus,
 @media screen and (-webkit-min-device-pixel-ratio:0) {
   @font-face {
     font-family: 'cruicons';
-    src: url('../font/cruicons.svg?54093663#cruicons') format('svg');
+    src: url('/fonts/cruicons.svg?54093663#cruicons') format('svg');
   }
 }
 */
@@ -4714,8 +4714,8 @@ td {
     vertical-align: middle;
     width: 74px;
     height: 54px;
-    background: url("assets/images/cru-logo.png");
-    background-image: url("assets/images/cru-logo.svg");
+    background: url("/images/cru-logo.png");
+    background-image: url("/images/cru-logo.svg");
     background-repeat: no-repeat;
     background-position: top center;
     background-size: contain; }


### PR DESCRIPTION
@tdaffron & @thejamesdempsey – I've mentioned this before, but we need to change the assets path structure in patterns to match AEM. Having to find/replace each time is getting missed too often. Patterns should store the assets so they can be called in "/fonts/" or "/images/" not "assets/fonts/" and "assets/images/"
