### PR TITLE
Cover photo

### DIFF
--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/clientlibs/tile.js
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/clientlibs/tile.js
@@ -48,9 +48,13 @@ Cru.components.tile = {
         var renditionWidget = container.findParentByType('dialog').getField("./imageRenditionName");
     	var width = container.getValue();
         renditionWidget.setValue(this.DEFAULT_RENDITION_VALUE);
+        if(width == "desk--one-whole coverphoto"){
+            renditionWidget.setValue("CruCoverPhoto880x374");
+        } else {
     	if(this.CRU_WIDTHS_VALUES_ARRAY.indexOf(width) != -1){
         	renditionWidget.setValue(this.CRU_RENDITION_VALUE);
 		}
+        }
     },
 
     validator : function(value, container) {

--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/dialog/items/items/tab2/items/width/options/@nodeinfo.xml
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/dialog/items/items/tab2/items/width/options/@nodeinfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <node nodeType="cq:WidgetCollection">
   <nodesOrder>
-    <value><![CDATA[option1,option20,option21,option3,option4]]></value>
+    <value><![CDATA[option1,option20,option21,option3,option4,option5]]></value>
   </nodesOrder>
   <properties />
   <mixins />

--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/dialog/items/items/tab2/items/width/options/option5/@nodeinfo.xml
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/dialog/items/items/tab2/items/width/options/option5/@nodeinfo.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<node nodeType="nt:unstructured">
+  <nodesOrder>
+    <value />
+  </nodesOrder>
+  <properties>
+    <property name="text" type="1" multiple="false">
+      <value><![CDATA[Whole CoverPhoto]]></value>
+    </property>
+    <property name="value" type="1" multiple="false">
+      <value><![CDATA[desk--one-whole coverphoto]]></value>
+    </property>
+  </properties>
+  <mixins />
+</node>
+

--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/xk.config/@nodeinfo.xml
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/xk.config/@nodeinfo.xml
@@ -7,6 +7,7 @@
     <property name="xk_availableRenditions" type="1" multiple="true">
       <value><![CDATA[CruHalf432x243]]></value>
       <value><![CDATA[Cru704x396]]></value>
+      <value><![CDATA[CruCoverPhoto880x374]]></value>
     </property>
     <property name="xk_defaultRenditionName" type="1" multiple="false">
       <value><![CDATA[CruHalf432x243]]></value>

--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/config/com.adobe.acs.commons.images.impl.NamedImageTransformerImpl-CruCoverPhoto880x374.config
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/config/com.adobe.acs.commons.images.impl.NamedImageTransformerImpl-CruCoverPhoto880x374.config
@@ -1,0 +1,2 @@
+name="CruCoverPhoto880x374"
+transforms=["resize:height\=374","crop:bounds\=0,0,880,374&center\=true"]


### PR DESCRIPTION
Modified tile component to enable selection of a cover photo option on Whole tiles
Created an image rendition called CruCoverPhoto880x374 which gives us a 2.35:1 aspect ratio option for cover photos
