### PR TITLE
Bug fixes - Large Curate Tile and Main Nav for Oracle

### DIFF
--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/main-navigation-oracle-givesite/@nodeinfo.xml
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/main-navigation-oracle-givesite/@nodeinfo.xml
@@ -5,7 +5,7 @@
   </nodesOrder>
   <properties>
     <property name="componentGroup" type="1" multiple="false">
-      <value><![CDATA[Admin]]></value>
+      <value><![CDATA[.hidden]]></value>
     </property>
     <property name="cq:noDecoration" type="6" multiple="false">
       <value>true</value>

--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile-large-curated-list/component.html
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile-large-curated-list/component.html
@@ -3,11 +3,11 @@
 <div class="grid__item masonry__item">
 	<div class="color-white box-shadow--thin p">
       {%#if content.title %}
-        {%#if content.path %}
-            <a href="{% content.path %}.html">
+        {%#if content.href %}
+            <a href="{% content.href %}">
         {%/if %}
         <h2>{% content.title %}</h2>
-        {%#if content.path %}
+        {%#if content.href %}
             </a>
         {%/if %}
       {%/if %}


### PR DESCRIPTION
Fixes content.html for Large Curated Tiles where content.path was being incorrectly used to detect if the author had set up a hyperlink for the tile's title. The correct value is content.href (content.path returns a path to a page the returns the html for the component on a page by itself... kinda handy but not for this).

Changes the componentGroup for the main-navigation-oracle-give component from Admin to .hidden to remove the component from sidekick.
