### PR TITLE
Fix margin bottom on Large Curated List Tile

### DIFF
--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile-large-curated-list/component.html
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile-large-curated-list/component.html
@@ -1,6 +1,6 @@
 {%#if list.pages %}
-<div class="grid mb">
-<div class="grid__item masonry__item">
+<div class="grid">
+<div class="grid__item masonry__item mb">
 	<div class="color-white box-shadow--thin p">
       {%#if content.title %}
         {%#if content.href %}


### PR DESCRIPTION
In order for masonry.js to correctly calculate the height of this tile, the "mb" class needs to be on the same div tag as "masonry_item" so I am removing "mb" from the div with "grid" and putting it on the "masonry_item".
