### PR TITLE
Daily Content Author Spacing

### DIFF
--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/daily-content/clientlibs/daily-content/DailyContent.js
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/daily-content/clientlibs/daily-content/DailyContent.js
@@ -60,6 +60,7 @@ Cru.components.DailyContent.elements = {
 
         if(date){
             var dateLi = document.createElement(this.LI);
+            dateLi.className = "accent";
             var dateTime = document.createElement(this.TIME);
             var dateNode = document.createTextNode(date);
             dateTime.appendChild(dateNode);


### PR DESCRIPTION
Fixes [Redmine #422](http://54.186.133.156/redmine/issues/422) by adding .accent the date, which gives it the appropriate spacing. Since Daily Content is an Angular.js app, we missed this since it's not in component.html.
