### PR TITLE
Add .full-width to Tile Images

### DIFF
--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/component.html
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/component.html
@@ -5,7 +5,7 @@
                     {%#if content.href %}
                          <a href="{% content.href %}">
                     {%/if %}
-                    <img src="{% content.imagePath %}" alt="{% content.title %}">
+                    <img src="{% content.imagePath %}" class="full-width" alt="{% content.title %}">
                     {%#if content.href %}
                          </a>
                     {%/if %}


### PR DESCRIPTION
Solves images not spanning full width of their containers.
