### PR TITLE
Fix Tile Links

### DIFF
--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/component.html
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/component.html
@@ -18,7 +18,7 @@
         	{%/if%}
       {%#if content.title %}
         {%#if content.href %}
-            <a href="{% content.href %}">
+            <a href="{% content.href %}"{%#if content.target%} target="_blank"{%/if%}>
         {%/if %}
         <h4>{% content.title %}</h4>
         {%#if content.href %}

--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/dialog/items/items/tab2/items/@nodeinfo.xml
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/dialog/items/items/tab2/items/@nodeinfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <node nodeType="cq:WidgetCollection">
   <nodesOrder>
-    <value><![CDATA[title,href,target,read-more,read-more-style,width,rendition]]></value>
+    <value><![CDATA[title,href,new-tab,read-more,read-more-style,width,rendition]]></value>
   </nodesOrder>
   <properties />
   <mixins />

--- a/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/dialog/items/items/tab2/items/new-tab/@nodeinfo.xml
+++ b/CQFiles/CruOrgApp/@JCR_ROOT/apps/CruOrgApp/components/section/tile/dialog/items/items/tab2/items/new-tab/@nodeinfo.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<node nodeType="cq:Widget">
+  <nodesOrder>
+    <value />
+  </nodesOrder>
+  <properties>
+    <property name="fieldLabel" type="1" multiple="false">
+      <value><![CDATA[Open in New Tab?]]></value>
+    </property>
+    <property name="name" type="1" multiple="false">
+      <value><![CDATA[./target]]></value>
+    </property>
+    <property name="type" type="1" multiple="false">
+      <value><![CDATA[checkbox]]></value>
+    </property>
+    <property name="xtype" type="1" multiple="false">
+      <value><![CDATA[selection]]></value>
+    </property>
+  </properties>
+  <mixins />
+</node>
+


### PR DESCRIPTION
The checkbox was not appearing in the dialog because of an uncaught error by @mattgasior. This corrects that.

This branch can be deleted.
